### PR TITLE
Add multi operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ title: Public Non-Fungible Token Emote Repository
 description: React to any Non-Fungible Tokens using Unicode emojis.
 author: Bruno Škvorc (@Swader), Steven Pineda (@steven2308), Stevan Bogosavljevic (@stevyhacker), Jan Turk (@ThunderDeliverer)
 discussions-to: https://ethereum-magicians.org/t/eip-6381-emotable-extension-for-non-fungible-tokens/12710
-status: Review
+status: Last Call
+last-call-deadline: 2023-05-02
 type: Standards Track
 category: ERC
 created: 2023-01-22
@@ -243,7 +244,7 @@ interface IERC6381 /*is IERC165*/ {
 The address of the Emotable repository smart contract is designed to resemble the function it serves. It starts with `0x311073` which is the abstract representation of `EMOTE`. The address is:
 
 ```
-TBA
+0x311073569e12f7770719497cd3b3aa2db0a0c3d9
 ```
 
 ## Rationale
@@ -264,7 +265,7 @@ The Emote repository standard is fully compatible with [ERC-721](./eip-721.md) a
 
 ## Test Cases
 
-Tests are included in [`emoteRepository.ts`](../assets/eip-6381/test/emoteRepository.ts).
+Tests are included in [`emotableRepository.ts`](../assets/eip-6381/test/emotableRepository.ts).
 
 To run them in terminal, you can use the following commands:
 
@@ -276,7 +277,7 @@ npx hardhat test
 
 ## Reference Implementation
 
-See [`EmoteRepository.sol`](../assets/eip-6381/contracts/EmoteRepository.sol).
+See [`EmotableRepository.sol`](../assets/eip-6381/contracts/EmotableRepository.sol).
 
 ## Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 /// @title ERC-6381 Emotable Extension for Non-Fungible Tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-6381
-/// @dev Note: the ERC-165 identifier for this interface is 0x761ce19f.
+/// @dev Note: the ERC-165 identifier for this interface is 0xd9fac55a.
 
 pragma solidity ^0.8.16;
 
@@ -151,6 +151,24 @@ interface IERC6381 /*is IERC165*/ {
     ) external view returns (bytes32);
 
     /**
+     * @notice Used to get multiple messages to be signed by the `emoter` in order for the reaction to be submitted by someone
+     *  else.
+     * @param collections An array of addresses of the collection smart contracts containing the tokens being emoted at
+     * @param tokenIds An array of IDs of the tokens being emoted
+     * @param emojis An arrau of unicode identifiers of the emojis
+     * @param states An array of boolean values signifying whether to emote (`true`) or undo (`false`) emote
+     * @param deadlines An array of UNIX timestamps of the deadlines for the signatures to be submitted
+     * @return The array of messages to be signed by the `emoter` in order for the reaction to be submitted by someone else
+     */
+    function prepareMessageToPresignEmote(
+        address collection,
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state,
+        uint256 deadline
+    ) external view returns (bytes32);
+
+    /**
      * @notice Used to emote or undo an emote on a token.
      * @dev Does nothing if attempting to set a pre-existent state.
      * @dev MUST emit the `Emoted` event is the state of the emote is changed.
@@ -190,6 +208,7 @@ interface IERC6381 /*is IERC165*/ {
      * @dev MUST revert if the lengths of the `collections`, `tokenIds`, `emojis` and `states` arrays are not equal.
      * @dev MUST revert if the `deadline` has passed.
      * @dev MUST revert if the recovered address is the zero address.
+     * @param emoter The address that presigned the emote
      * @param collection The address of the collection smart contract containing the token being emoted at
      * @param tokenId IDs of the token being emoted
      * @param emoji Unicode identifier of the emoji
@@ -200,6 +219,7 @@ interface IERC6381 /*is IERC165*/ {
      * @param s `s` value of an ECDSA signature of the message obtained via `prepareMessageToPresignEmote`
      */
     function presignedEmote(
+        address emoter,
         address collection,
         uint256 tokenId,
         bytes4 emoji,
@@ -217,6 +237,7 @@ interface IERC6381 /*is IERC165*/ {
      * @dev MUST revert if the lengths of the `collections`, `tokenIds`, `emojis` and `states` arrays are not equal.
      * @dev MUST revert if the `deadline` has passed.
      * @dev MUST revert if the recovered address is the zero address.
+     * @param emoters An array of addresses of the accounts that presigned the emotes
      * @param collections An array of addresses of the collections containing the tokens being emoted at
      * @param tokenIds An array of IDs of the tokens being emoted
      * @param emojis An array of unicode identifiers of the emojis
@@ -227,6 +248,7 @@ interface IERC6381 /*is IERC165*/ {
      * @param s An array of `s` values of an ECDSA signatures of the messages obtained via `prepareMessageToPresignEmote`
      */
     function bulkPresignedEmote(
+        address[] memory emoters,
         address[] memory collections,
         uint256[] memory tokenIds,
         bytes4[] memory emojis,

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ interface IERC6381 /*is IERC165*/ {
     /**
      * @notice Used to get the message to be signed by the `emoter` in order for the reaction to be submitted by someone
      *  else.
-     * @param collection The addresses of the collection smart contract containing the token being emoted at
+     * @param collection The address of the collection smart contract containing the token being emoted at
      * @param tokenId ID of the token being emoted
      * @param emoji Unicode identifier of the emoji
      * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
@@ -190,7 +190,7 @@ interface IERC6381 /*is IERC165*/ {
      * @dev MUST revert if the lengths of the `collections`, `tokenIds`, `emojis` and `states` arrays are not equal.
      * @dev MUST revert if the `deadline` has passed.
      * @dev MUST revert if the recovered address is the zero address.
-     * @param collection Addresses of the collections containing the token being emoted at
+     * @param collection The address of the collection smart contract containing the token being emoted at
      * @param tokenId IDs of the token being emoted
      * @param emoji Unicode identifier of the emoji
      * @param states Boolean value signifying whether to emote (`true`) or undo (`false`) emote
@@ -300,7 +300,7 @@ The impressions could have been done using user-supplied strings or numeric valu
 Initially we set out to create an emotable extension to be used with any ERC-721 compilant tokens. However, we realized that the proposal would be more useful if it was a common-good repository of emotable tokens. This way, the tokens that can be reacted to are not only the new ones but also the old ones that have been around since before the proposal.\
 In line with this decision, we decided to calculate a deterministic address for the repository smart contract. This way, the repository can be used by any NFT collection without the need to search for the address on the given chain.
 4. **Should we include only single-action operations, only multi-action operations, or both?**\
-We've considered including only single-action operations, where the user is only able to react with a single emoji to a sinle token, but we decided to include both single-action and multi-action operations. This way, the users can choose whether they want to emote or undo emote on a single token or on multiple tokens at once.\
+We've considered including only single-action operations, where the user is only able to react with a single emoji to a single token, but we decided to include both single-action and multi-action operations. This way, the users can choose whether they want to emote or undo emote on a single token or on multiple tokens at once.\
 This decision was made for the long-term viability of the proposal. Based on the gas cost of the network and the number of tokens in the collection, the user can choose the most cost-effective way of emoting.
 5. **Should we add the ability to emote on someone else's behalf?**\
 While we did not intend to add this as part of the proposal when drafting it, we realized that it would be a useful feature for it. This way, the users can emote on behalf of someone else, for example, if they are not able to do it themselves or if the emote is earned through an off-chain activity.
@@ -310,7 +310,7 @@ Using ECDSA signatures, we can ensure that the user has given their consent to e
 7. **Should we add chain ID as a parameter when reacting to a token?**\
 During the course of discussion of the proposal, a suggestion arose that we could add chain ID as a parameter when reacting to a token. This would allow the users to emote on the token of one chain on another chain.\
 We decided against this as we feel that additional parameter would rarely be used and would add additional cost to the reaction transactions. If the collection smart contract wants to utilize on-chain emotes to tokens they contain, they require the reactions to be recorded on the same chain. Marketplaces and wallets integrating this proposal will rely on reactions to reside in the same chain as well, because if chain ID parameter was supported this would mean that they would need to query the repository smart contract on all of the chains the repository is deployed in order to get the reactions for a given token.\
-Additionally, if the collection creator wants users to record their reactions on a different chain, they can still direct the users to do just that. The repository does not validate the existence of the token being reacted to, which in theory means that you can react to non-existent token or to a token that does not exist yet. The likelyhood of a differet collection existing at the same address on another chain is significantly low, so the users can react using the collection's address on another chain and it is very unlikely that they will unintentionally react to another collection's token.
+Additionally, if the collection creator wants users to record their reactions on a different chain, they can still direct the users to do just that. The repository does not validate the existence of the token being reacted to, which in theory means that you can react to non-existent token or to a token that does not exist yet. The likelihood of a different collection existing at the same address on another chain is significantly low, so the users can react using the collection's address on another chain and it is very unlikely that they will unintentionally react to another collection's token.
 
 ## Backwards Compatibility
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ While we did not intend to add this as part of the proposal when drafting it, we
 6. **How do we ensure that emoting on someone else's behalf is legitimate?**\
 We could add delegates to the proposal; when a user delegates their right to emote to someone else, the delegate can emote on their behalf. However, this would add a lot of complexity and additional logic to the proposal.\
 Using ECDSA signatures, we can ensure that the user has given their consent to emote on their behalf. This way, the user can sign a message with the parameters of the emote and the signature can be submitted by someone else.
+7. **Should we add chain ID as a parameter when reacting to a token?**\
+During the course of discussion of the proposal, a suggestion arose that we could add chain ID as a parameter when reacting to a token. This would allow the users to emote on the token of one chain on another chain.\
+We decided against this as we feel that additional parameter would rarely be used and would add additional cost to the reaction transactions. If the collection smart contract wants to utilize on-chain emotes to tokens they contain, they require the reactions to be recorded on the same chain. Marketplaces and wallets integrating this proposal will rely on reactions to reside in the same chain as well, because if chain ID parameter was supported this would mean that they would need to query the repository smart contract on all of the chains the repository is deployed in order to get the reactions for a given token.\
+Additionally, if the collection creator wants users to record their reactions on a different chain, they can still direct the users to do just that. The repository does not validate the existence of the token being reacted to, which in theory means that you can react to non-existent token or to a token that does not exist yet. The likelyhood of a differet collection existing at the same address on another chain is significantly low, so the users can react using the collection's address on another chain and it is very unlikely that they will unintentionally react to another collection's token.
 
 ## Backwards Compatibility
 

--- a/assets/contracts/EmotableRepository.sol
+++ b/assets/contracts/EmotableRepository.sol
@@ -174,7 +174,7 @@ contract EmotableRepository is IERC6381 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public {
+    ) public view {
         if(block.timestamp > deadline){
             revert ExpiredPresignedEmote();
         }

--- a/assets/contracts/EmotableRepository.sol
+++ b/assets/contracts/EmotableRepository.sol
@@ -5,7 +5,23 @@ pragma solidity ^0.8.16;
 import "./IERC6381.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
+error BulkParametersOfUnequalLength();
+error ExpiredPresignedEmote();
+error InvalidSignature();
+
 contract EmotableRepository is IERC6381 {
+    bytes32 public constant DOMAIN_SEPARATOR = keccak256(
+        abi.encode(
+            "ERC-6381: Public Non-Fungible Token Emote Repository",
+            "1",
+            block.chainid,
+            address(this)
+        )
+    );
+    bytes32 public constant EMOTE_TYPEHASH = keccak256(
+        "emote(address collection,uint256 tokenId,bytes4 emoji,bool state)"
+    );
+
     // Used to avoid double emoting and control undoing
     mapping(address => mapping(address => mapping(uint256 => mapping(bytes4 => uint256))))
         private _emotesUsedByEmoter; // Cheaper than using a bool
@@ -20,6 +36,28 @@ contract EmotableRepository is IERC6381 {
         return _emotesPerToken[collection][tokenId][emoji];
     }
 
+    function bulkEmoteCountOf(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis
+    ) public view returns (uint256[] memory) {
+        if(
+            collections.length != tokenIds.length ||
+                collections.length != emojis.length
+        ){
+            revert BulkParametersOfUnequalLength();
+        }
+
+        uint256[] memory counts = new uint256[](collections.length);
+        for (uint256 i; i < collections.length; ) {
+            counts[i] = _emotesPerToken[collections[i]][tokenIds[i]][emojis[i]];
+            unchecked {
+                ++i;
+            }
+        }
+        return counts;
+    }
+
     function hasEmoterUsedEmote(
         address emoter,
         address collection,
@@ -27,6 +65,30 @@ contract EmotableRepository is IERC6381 {
         bytes4 emoji
     ) public view returns (bool) {
         return _emotesUsedByEmoter[emoter][collection][tokenId][emoji] == 1;
+    }
+
+    function haveEmotersUsedEmotes(
+        address[] memory emoters,
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis
+    ) public view returns (bool[] memory) {
+        if(
+            emoters.length != collections.length ||
+                emoters.length != tokenIds.length ||
+                emoters.length != emojis.length
+        ){
+            revert BulkParametersOfUnequalLength();
+        }
+
+        bool[] memory states = new bool[](collections.length);
+        for (uint256 i; i < collections.length; ) {
+            states[i] = _emotesUsedByEmoter[emoters[i]][collections[i]][tokenIds[i]][emojis[i]] == 1;
+            unchecked {
+                ++i;
+            }
+        }
+        return states;
     }
 
     function emote(
@@ -48,6 +110,162 @@ contract EmotableRepository is IERC6381 {
                 ? 1
                 : 0;
             emit Emoted(msg.sender, collection, tokenId, emoji, state);
+        }
+    }
+
+    function bulkEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states
+    ) public {
+        if(
+            collections.length != tokenIds.length ||
+                collections.length != emojis.length ||
+                collections.length != states.length
+        ){
+            revert BulkParametersOfUnequalLength();
+        }
+
+        bool currentVal;
+        for (uint256 i; i < emoters.length; ) {
+            currentVal = _emotesUsedByEmoter[msg.sender][collections[i]][tokenIds[i]][
+                emojis[i]
+            ] == 1;
+            if (currentVal != states[i]) {
+                if (states[i]) {
+                    _emotesPerToken[collections[i]][tokenIds[i]][emojis[i]] += 1;
+                } else {
+                    _emotesPerToken[collections[i]][tokenIds[i]][emojis[i]] -= 1;
+                }
+                _emotesUsedByEmoter[msg.sender][collections[i]][tokenIds[i]][emojis[i]] = states[i]
+                    ? 1
+                    : 0;
+                emit Emoted(msg.sender, collections[i], tokenIds[i], emojis[i], states[i]);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function presignedEmote(
+        address collection,
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if(block.timestamp > deadline){
+            revert ExpiredPresignedEmote();
+        }
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        EMOTE_TYPEHASH,
+                        collection,
+                        tokenId,
+                        emoji,
+                        state,
+                        deadline
+                    )
+                )
+            )
+        );
+        address signer = ecrecover(digest, v, r, s);
+        if(signer == address(0)){
+            revert InvalidSignature();
+        }
+        
+        bool currentVal = _emotesUsedByEmoter[signer][collection][tokenId][
+            emoji
+        ] == 1;
+        if (currentVal != state) {
+            if (state) {
+                _emotesPerToken[collection][tokenId][emoji] += 1;
+            } else {
+                _emotesPerToken[collection][tokenId][emoji] -= 1;
+            }
+            _emotesUsedByEmoter[signer][collection][tokenId][emoji] = state
+                ? 1
+                : 0;
+            emit Emoted(signer, collection, tokenId, emoji, state);
+        }
+    }
+    
+    function bulkPresignedEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states,
+        uint256[] memory deadlines,
+        uint8[] memory v,
+        bytes32[] memory r,
+        bytes32[] memory s
+    ) public {
+        if(
+            collections.length != tokenIds.length ||
+                collections.length != emojis.length ||
+                collections.length != states.length ||
+                collections.length != deadlines.length ||
+                collections.length != v.length ||
+                collections.length != r.length ||
+                collections.length != s.length
+        ){
+            revert BulkParametersOfUnequalLength();
+        }
+
+        bytes32 digest;
+        address signer;
+        bool currentVal;
+        for (uint256 i; i < emoters.length; ) {
+            if (block.timestamp > deadlines[i]){
+                revert ExpiredPresignedEmote();
+            }
+            digest = keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    DOMAIN_SEPARATOR,
+                    keccak256(
+                        abi.encode(
+                            EMOTE_TYPEHASH,
+                            collections[i],
+                            tokenIds[i],
+                            emojis[i],
+                            states[i],
+                            deadlines[i]
+                        )
+                    )
+                )
+            );
+            signer = ecrecover(digest, v[i], r[i], s[i]);
+            if(signer == address(0)){
+                revert InvalidSignature();
+            }
+            
+            currentVal = _emotesUsedByEmoter[signer][collections[i]][tokenIds[i]][
+                emojis[i]
+            ] == 1;
+            if (currentVal != states[i]) {
+                if (states[i]) {
+                    _emotesPerToken[collections[i]][tokenIds[i]][emojis[i]] += 1;
+                } else {
+                    _emotesPerToken[collections[i]][tokenIds[i]][emojis[i]] -= 1;
+                }
+                _emotesUsedByEmoter[signer][collections[i]][tokenIds[i]][emojis[i]] = states[i]
+                    ? 1
+                    : 0;
+                emit Emoted(signer, collections[i], tokenIds[i], emojis[i], states[i]);
+            }
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/assets/contracts/IERC6381.sol
+++ b/assets/contracts/IERC6381.sol
@@ -17,6 +17,12 @@ interface IERC6381 {
         bytes4 emoji
     ) external view returns (uint256);
 
+    function bulkEmoteCountOf(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis
+    ) external view returns (uint256[] memory);
+
     function hasEmoterUsedEmote(
         address emoter,
         address collection,
@@ -24,10 +30,46 @@ interface IERC6381 {
         bytes4 emoji
     ) external view returns (bool);
 
+    function haveEmotersUsedEmotes(
+        address[] memory emoters,
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis
+    ) external view returns (bool[] memory);
+
     function emote(
         address collection,
         uint256 tokenId,
         bytes4 emoji,
         bool state
+    ) external;
+
+    function bulkEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states
+    ) external;
+
+    function presignedEmote(
+        address collection,
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function bulkPresignedEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states,
+        uint256[] memory deadlines,
+        uint8[] memory v,
+        bytes32[] memory r,
+        bytes32[] memory s
     ) external;
 }

--- a/assets/contracts/IERC6381.sol
+++ b/assets/contracts/IERC6381.sol
@@ -44,6 +44,14 @@ interface IERC6381 {
         bool state,
         uint256 deadline
     ) external view returns (bytes32);
+    
+    function bulkPrepareMessagesToPresignEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states,
+        uint256[] memory deadlines
+    ) external view returns (bytes32[] memory);
 
     function emote(
         address collection,
@@ -60,6 +68,7 @@ interface IERC6381 {
     ) external;
 
     function presignedEmote(
+        address emoter,
         address collection,
         uint256 tokenId,
         bytes4 emoji,
@@ -71,6 +80,7 @@ interface IERC6381 {
     ) external;
 
     function bulkPresignedEmote(
+        address[] memory emoters,
         address[] memory collections,
         uint256[] memory tokenIds,
         bytes4[] memory emojis,

--- a/assets/contracts/IERC6381.sol
+++ b/assets/contracts/IERC6381.sol
@@ -37,6 +37,14 @@ interface IERC6381 {
         bytes4[] memory emojis
     ) external view returns (bool[] memory);
 
+    function prepareMessageToPresignEmote(
+        address collection,
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state,
+        uint256 deadline
+    ) external view returns (bytes32);
+
     function emote(
         address collection,
         uint256 tokenId,

--- a/assets/test/emotableRepository.ts
+++ b/assets/test/emotableRepository.ts
@@ -135,61 +135,148 @@ describe("RMRKEmotableRepositoryMock", async function () {
 
     it("can bulk emote", async function () {
       expect(
-        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([bn(0), bn(0)]);
-      
+
       expect(
-        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([false, false]);
-      
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true, true]
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
-        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
-      
-        expect(
-        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
-      ).to.eql([bn(1), bn(1)]);
-      
+
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [true, true]
+        )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          true
+        )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji2,
+          true
+        );
+
       expect(
-        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
+      ).to.eql([bn(1), bn(1)]);
+
+      expect(
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([true, true]);
     });
 
     it("can bulk undo emote", async function () {
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true, true]
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
-        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
-      
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [true, true]
+        )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          true
+        )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji2,
+          true
+        );
+
       expect(
-        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([bn(1), bn(1)]);
-      
+
       expect(
-        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([true, true]);
 
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [false, false]
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, false)
-        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, false);
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [false, false]
+        )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          false
+        )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji2,
+          false
+        );
 
       expect(
-        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([bn(0), bn(0)]);
-      
+
       expect(
-        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([false, false]);
     });
 
@@ -197,65 +284,123 @@ describe("RMRKEmotableRepositoryMock", async function () {
       await repository.emote(token.address, tokenId, emoji2, true);
 
       expect(
-        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([bn(0), bn(1)]);
-      
+
       expect(
-        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
       ).to.eql([false, true]);
 
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true, false]
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
-        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, false);
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [true, false]
+        )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          true
+        )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji2,
+          false
+        );
 
-        expect(
-          await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
-        ).to.eql([bn(1), bn(0)]);
-        
-        expect(
-          await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
-        ).to.eql([true, false]);
+      expect(
+        await repository.bulkEmoteCountOf(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
+      ).to.eql([bn(1), bn(0)]);
+
+      expect(
+        await repository.haveEmotersUsedEmotes(
+          [owner.address, owner.address],
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2]
+        )
+      ).to.eql([true, false]);
     });
 
     it("can not bulk emote if passing arrays of different length", async function () {
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true]
-      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [true]
+        )
+      ).to.be.revertedWithCustomError(
+        repository,
+        "BulkParametersOfUnequalLength"
+      );
 
+      await expect(
+        repository.bulkEmote(
+          [token.address],
+          [tokenId, tokenId],
+          [emoji1, emoji2],
+          [true, true]
+        )
+      ).to.be.revertedWithCustomError(
+        repository,
+        "BulkParametersOfUnequalLength"
+      );
 
-      await expect(repository.bulkEmote(
-        [token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true, true]
-      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId],
+          [emoji1, emoji2],
+          [true, true]
+        )
+      ).to.be.revertedWithCustomError(
+        repository,
+        "BulkParametersOfUnequalLength"
+      );
 
-
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId],
-        [emoji1, emoji2],
-        [true, true]
-      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
-
-
-      await expect(repository.bulkEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1],
-        [true, true]
-      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+      await expect(
+        repository.bulkEmote(
+          [token.address, token.address],
+          [tokenId, tokenId],
+          [emoji1],
+          [true, true]
+        )
+      ).to.be.revertedWithCustomError(
+        repository,
+        "BulkParametersOfUnequalLength"
+      );
     });
 
     it("can use presigned emote to react to token", async function () {
-      const message = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji1, true, bn(9999999999));
+      const message = await repository.prepareMessageToPresignEmote(
+        token.address,
+        tokenId,
+        emoji1,
+        true,
+        bn(9999999999)
+      );
 
       const signature = await owner.signMessage(ethers.utils.arrayify(message));
 
@@ -263,24 +408,52 @@ describe("RMRKEmotableRepositoryMock", async function () {
       const s: string = "0x" + signature.substring(66, 130);
       const v: number = parseInt(signature.substring(130, 132), 16);
 
-      await expect(repository.connect(addrs[0]).presignedEmote(
+      await expect(
+        repository
+          .connect(addrs[0])
+          .presignedEmote(
+            token.address,
+            tokenId,
+            emoji1,
+            true,
+            bn(9999999999),
+            v,
+            r,
+            s
+          )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          true
+        );
+    });
+
+    it("can use presigned emotes to bulk react to token", async function () {
+      const message1 = await repository.prepareMessageToPresignEmote(
         token.address,
         tokenId,
         emoji1,
         true,
-        bn(9999999999),
-        v,
-        r,
-        s
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true);
-    });
+        bn(9999999999)
+      );
+      const message2 = await repository.prepareMessageToPresignEmote(
+        token.address,
+        tokenId,
+        emoji2,
+        true,
+        bn(9999999999)
+      );
 
-    it("can use presigned emotes to bulk react to token", async function () {
-      const message1 = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji1, true, bn(9999999999));
-      const message2 = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji2, true, bn(9999999999));
-
-      const signature1 = await owner.signMessage(ethers.utils.arrayify(message1));
-      const signature2 = await owner.signMessage(ethers.utils.arrayify(message2));
+      const signature1 = await owner.signMessage(
+        ethers.utils.arrayify(message1)
+      );
+      const signature2 = await owner.signMessage(
+        ethers.utils.arrayify(message2)
+      );
 
       const r1: string = signature1.substring(0, 66);
       const s1: string = "0x" + signature1.substring(66, 130);
@@ -289,17 +462,36 @@ describe("RMRKEmotableRepositoryMock", async function () {
       const s2: string = "0x" + signature2.substring(66, 130);
       const v2: number = parseInt(signature2.substring(130, 132), 16);
 
-      await expect(repository.connect(addrs[0]).bulkPresignedEmote(
-        [token.address, token.address],
-        [tokenId, tokenId],
-        [emoji1, emoji2],
-        [true, true],
-        [bn(9999999999), bn(9999999999)],
-        [v1, v2],
-        [r1, r2],
-        [s1, s2]
-      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
-      .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
+      await expect(
+        repository
+          .connect(addrs[0])
+          .bulkPresignedEmote(
+            [token.address, token.address],
+            [tokenId, tokenId],
+            [emoji1, emoji2],
+            [true, true],
+            [bn(9999999999), bn(9999999999)],
+            [v1, v2],
+            [r1, r2],
+            [s1, s2]
+          )
+      )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji1,
+          true
+        )
+        .to.emit(repository, "Emoted")
+        .withArgs(
+          owner.address,
+          token.address,
+          tokenId.toNumber(),
+          emoji2,
+          true
+        );
     });
   });
 });

--- a/assets/test/emotableRepository.ts
+++ b/assets/test/emotableRepository.ts
@@ -41,7 +41,7 @@ describe("RMRKEmotableRepositoryMock", async function () {
   });
 
   it("can support IERC6381", async function () {
-    expect(await repository.supportsInterface("0x761ce19f")).to.equal(true);
+    expect(await repository.supportsInterface("0xd9fac55a")).to.equal(true);
   });
 
   it("can support IERC165", async function () {
@@ -412,6 +412,7 @@ describe("RMRKEmotableRepositoryMock", async function () {
         repository
           .connect(addrs[0])
           .presignedEmote(
+            owner.address,
             token.address,
             tokenId,
             emoji1,
@@ -433,26 +434,19 @@ describe("RMRKEmotableRepositoryMock", async function () {
     });
 
     it("can use presigned emotes to bulk react to token", async function () {
-      const message1 = await repository.prepareMessageToPresignEmote(
-        token.address,
-        tokenId,
-        emoji1,
-        true,
-        bn(9999999999)
-      );
-      const message2 = await repository.prepareMessageToPresignEmote(
-        token.address,
-        tokenId,
-        emoji2,
-        true,
-        bn(9999999999)
+      const messages = await repository.bulkPrepareMessagesToPresignEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, true],
+        [bn(9999999999), bn(9999999999)]
       );
 
       const signature1 = await owner.signMessage(
-        ethers.utils.arrayify(message1)
+        ethers.utils.arrayify(messages[0])
       );
       const signature2 = await owner.signMessage(
-        ethers.utils.arrayify(message2)
+        ethers.utils.arrayify(messages[1])
       );
 
       const r1: string = signature1.substring(0, 66);
@@ -466,6 +460,7 @@ describe("RMRKEmotableRepositoryMock", async function () {
         repository
           .connect(addrs[0])
           .bulkPresignedEmote(
+            [owner.address, owner.address],
             [token.address, token.address],
             [tokenId, tokenId],
             [emoji1, emoji2],

--- a/assets/test/emotableRepository.ts
+++ b/assets/test/emotableRepository.ts
@@ -40,8 +40,8 @@ describe("RMRKEmotableRepositoryMock", async function () {
     repository = await loadFixture(emotableRepositoryFixture);
   });
 
-  it("can support IEmotableRepository", async function () {
-    expect(await repository.supportsInterface("0x08eb97a6")).to.equal(true);
+  it("can support IERC6381", async function () {
+    expect(await repository.supportsInterface("0x761ce19f")).to.equal(true);
   });
 
   it("can support IERC165", async function () {
@@ -131,6 +131,175 @@ describe("RMRKEmotableRepositoryMock", async function () {
       expect(
         await repository.emoteCountOf(token.address, tokenId, emoji2)
       ).to.equal(bn(0));
+    });
+
+    it("can bulk emote", async function () {
+      expect(
+        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([bn(0), bn(0)]);
+      
+      expect(
+        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([false, false]);
+      
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, true]
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
+        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
+      
+        expect(
+        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([bn(1), bn(1)]);
+      
+      expect(
+        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([true, true]);
+    });
+
+    it("can bulk undo emote", async function () {
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, true]
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
+        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
+      
+      expect(
+        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([bn(1), bn(1)]);
+      
+      expect(
+        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([true, true]);
+
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [false, false]
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, false)
+        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, false);
+
+      expect(
+        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([bn(0), bn(0)]);
+      
+      expect(
+        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([false, false]);
+    });
+
+    it("can bulk emote and unemote at the same time", async function () {
+      await repository.emote(token.address, tokenId, emoji2, true);
+
+      expect(
+        await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([bn(0), bn(1)]);
+      
+      expect(
+        await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+      ).to.eql([false, true]);
+
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, false]
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
+        .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, false);
+
+        expect(
+          await repository.bulkEmoteCountOf([token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        ).to.eql([bn(1), bn(0)]);
+        
+        expect(
+          await repository.haveEmotersUsedEmotes([owner.address, owner.address], [token.address, token.address], [tokenId, tokenId], [emoji1, emoji2])
+        ).to.eql([true, false]);
+    });
+
+    it("can not bulk emote if passing arrays of different length", async function () {
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true]
+      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+
+
+      await expect(repository.bulkEmote(
+        [token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, true]
+      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+
+
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId],
+        [emoji1, emoji2],
+        [true, true]
+      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+
+
+      await expect(repository.bulkEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1],
+        [true, true]
+      )).to.be.revertedWithCustomError(repository, 'BulkParametersOfUnequalLength');
+    });
+
+    it("can use presigned emote to react to token", async function () {
+      const message = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji1, true, bn(9999999999));
+
+      const signature = await owner.signMessage(ethers.utils.arrayify(message));
+
+      const r: string = signature.substring(0, 66);
+      const s: string = "0x" + signature.substring(66, 130);
+      const v: number = parseInt(signature.substring(130, 132), 16);
+
+      await expect(repository.connect(addrs[0]).presignedEmote(
+        token.address,
+        tokenId,
+        emoji1,
+        true,
+        bn(9999999999),
+        v,
+        r,
+        s
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true);
+    });
+
+    it("can use presigned emotes to bulk react to token", async function () {
+      const message1 = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji1, true, bn(9999999999));
+      const message2 = await repository.prepareMessageToPresignEmote(token.address, tokenId, emoji2, true, bn(9999999999));
+
+      const signature1 = await owner.signMessage(ethers.utils.arrayify(message1));
+      const signature2 = await owner.signMessage(ethers.utils.arrayify(message2));
+
+      const r1: string = signature1.substring(0, 66);
+      const s1: string = "0x" + signature1.substring(66, 130);
+      const v1: number = parseInt(signature1.substring(130, 132), 16);
+      const r2: string = signature2.substring(0, 66);
+      const s2: string = "0x" + signature2.substring(66, 130);
+      const v2: number = parseInt(signature2.substring(130, 132), 16);
+
+      await expect(repository.connect(addrs[0]).bulkPresignedEmote(
+        [token.address, token.address],
+        [tokenId, tokenId],
+        [emoji1, emoji2],
+        [true, true],
+        [bn(9999999999), bn(9999999999)],
+        [v1, v2],
+        [r1, r2],
+        [s1, s2]
+      )).to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji1, true)
+      .to.emit(repository, "Emoted").withArgs(owner.address, token.address, tokenId.toNumber(), emoji2, true);
     });
   });
 });


### PR DESCRIPTION
I added the changes that we discussed. The only things that I'm still on the fence are:

- Should we add a multi-getter for messages to be signed as well? I think that we might want to do that to provide full functionality, but at the same time, the single getter is a view function that doesn't really cause any gas waste if called multiple times 🤔 
- Should we require that the user using presigned emote provide the signer of the message? If we don't, an incorrect address could be recovered and the signature would still pass. I see the possibility for abuse here as you could simply generate new accounts and sign emotes for them and then just send those signatures and farm emotes..